### PR TITLE
Fix Drawable tint using ColorFilter

### DIFF
--- a/recycler-view-divider/src/main/kotlin/com/fondesa/recyclerviewdivider/DividerItemDecoration.kt
+++ b/recycler-view-divider/src/main/kotlin/com/fondesa/recyclerviewdivider/DividerItemDecoration.kt
@@ -16,8 +16,9 @@
 
 package com.fondesa.recyclerviewdivider
 
-import android.content.res.ColorStateList
 import android.graphics.Canvas
+import android.graphics.PorterDuff
+import android.graphics.PorterDuffColorFilter
 import android.graphics.Rect
 import android.graphics.drawable.Drawable
 import android.view.View
@@ -202,9 +203,17 @@ internal class DividerItemDecoration(
     }
 
     private fun Drawable.tinted(@ColorInt tintColor: Int?): Drawable {
-        val tintList = tintColor?.let { color -> ColorStateList.valueOf(color) }
+        // We can't use setColorTintList() here because setColorTintList(null) doesn't behave correctly when the drawable which
+        // should be tinted is completely opaque.
+        // A similar issue is reported here: https://issuetracker.google.com/issues/141678225.
+        // e.g. using `addDivider()` with a DayNight theme and the dark mode on, the original drawable color is changed after
+        // the call to setColorTintList(null) used to reset the tint list for each divider.
         val wrappedDrawable = DrawableCompat.wrap(this)
-        DrawableCompat.setTintList(wrappedDrawable, tintList)
+        if (tintColor == null) {
+            wrappedDrawable.clearColorFilter()
+        } else {
+            wrappedDrawable.colorFilter = PorterDuffColorFilter(tintColor, PorterDuff.Mode.SRC_ATOP)
+        }
         return wrappedDrawable
     }
 


### PR DESCRIPTION
### Description
<!--
Describe the changes you have made on a high level in the project.
If this PR is related to an issue, reference it here.
-->
Related issue #45 

Tinting a GradientDrawable with a color which isn't fully opaque, fails only on dark theme.

It's very similar to this issue on Android: https://issuetracker.google.com/issues/141678225
It can be reproduce using a `DayNight` theme and enabling the dark mode.

The problem is that the default divider color on API > 21 is `#ffdadce0` on light theme and `#85ffffff` on dark theme, so on dark mode the bug appears.