### PR TITLE
Fix tint not applied when tint color was #FFFFFF

### DIFF
--- a/recycler-view-divider/src/main/kotlin/com/fondesa/recyclerviewdivider/tint/GetDefaultTintColor.kt
+++ b/recycler-view-divider/src/main/kotlin/com/fondesa/recyclerviewdivider/tint/GetDefaultTintColor.kt
@@ -31,5 +31,5 @@ import com.fondesa.recyclerviewdivider.withAttribute
  */
 @ColorInt
 internal fun Context.getThemeTintColor(): Int? = withAttribute(R.attr.recyclerViewDividerTint) {
-    getColor(0, -1).takeIf { it != -1 }
+    getColorStateList(0)?.defaultColor
 }


### PR DESCRIPTION
The color `#FFFFFF` is equivalent to `-1` so the tint wasn't applied in that case.