### PR TITLE
Handle cache on DividerItemDecoration

### DIFF
--- a/recycler-view-divider/src/main/kotlin/com/fondesa/recyclerviewdivider/BaseDividerItemDecoration.kt
+++ b/recycler-view-divider/src/main/kotlin/com/fondesa/recyclerviewdivider/BaseDividerItemDecoration.kt
@@ -31,6 +31,8 @@ import androidx.recyclerview.widget.RecyclerView
 public abstract class BaseDividerItemDecoration(
     @VisibleForTesting internal val asSpace: Boolean
 ) : RecyclerView.ItemDecoration() {
+    private var attachStateListenerHolder: AttachStateListenerHolder? = null
+    private var observerHolder: ObserverHolder? = null
 
     /**
      * Adds this decoration to the given [RecyclerView].
@@ -82,11 +84,21 @@ public abstract class BaseDividerItemDecoration(
      */
     protected abstract fun onDraw(canvas: Canvas, recyclerView: RecyclerView, layoutManager: RecyclerView.LayoutManager, itemCount: Int)
 
+    /**
+     * Callback invoked when the the adapter's data changes.
+     * Specifically, this callback is invoked every time a method of [RecyclerView.AdapterDataObserver] is invoked.
+     */
+    protected open fun onDataChanged() {
+        // No-op.
+    }
+
     final override fun getItemOffsets(outRect: Rect, view: View, parent: RecyclerView, state: RecyclerView.State) {
+        parent.setupAttachStateListener()
         // Avoids to call super.getItemOffsets to avoid to pre-compute the layout position of the item.
         // To avoid to depend on the implementations of this class, set the offsets to zero by default.
         outRect.setEmpty()
         val adapter = parent.adapter ?: return
+        adapter.setupDataObserver()
         val itemCount = adapter.itemCount
         if (itemCount == 0) return
         val layoutManager = parent.layoutManager ?: return
@@ -96,9 +108,11 @@ public abstract class BaseDividerItemDecoration(
 
     final override fun onDraw(c: Canvas, parent: RecyclerView, state: RecyclerView.State) {
         super.onDraw(c, parent, state)
+        parent.setupAttachStateListener()
         // The divider shouldn't be drawn if it's configured as a space.
         if (asSpace) return
         val adapter = parent.adapter ?: return
+        adapter.setupDataObserver()
         val itemCount = adapter.itemCount
         if (itemCount == 0) return
         val layoutManager = parent.layoutManager ?: return
@@ -113,5 +127,66 @@ public abstract class BaseDividerItemDecoration(
     @Suppress("DEPRECATION")
     final override fun onDraw(c: Canvas, parent: RecyclerView) {
         super.onDraw(c, parent)
+    }
+
+    private fun RecyclerView.setupAttachStateListener() {
+        // If the RecyclerView didn't change, we shouldn't add a new listener.
+        if (this == attachStateListenerHolder?.recyclerView) return
+        clearAttachStateListenerHolder()
+        val listener = OnRecyclerViewDetachedFromWindow(::destroy)
+        attachStateListenerHolder = AttachStateListenerHolder(this, listener)
+        addOnAttachStateChangeListener(listener)
+    }
+
+    private fun RecyclerView.Adapter<*>.setupDataObserver() {
+        // If the adapter didn't change, we shouldn't register a new observer.
+        if (this == observerHolder?.adapter) return
+        clearObserverHolder()
+        val observer = DataObserver(::onDataChanged)
+        observerHolder = ObserverHolder(this, observer)
+        registerAdapterDataObserver(observer)
+    }
+
+    private fun clearAttachStateListenerHolder() {
+        attachStateListenerHolder?.let { (recyclerView, listener) ->
+            recyclerView.removeOnAttachStateChangeListener(listener)
+        }
+        attachStateListenerHolder = null
+    }
+
+    private fun clearObserverHolder() {
+        observerHolder?.let { (adapter, observer) ->
+            adapter.unregisterAdapterDataObserver(observer)
+        }
+        observerHolder = null
+    }
+
+    private fun destroy() {
+        clearObserverHolder()
+        clearAttachStateListenerHolder()
+    }
+
+    private data class AttachStateListenerHolder(
+        val recyclerView: RecyclerView,
+        val listener: View.OnAttachStateChangeListener
+    )
+
+    private data class ObserverHolder(
+        val adapter: RecyclerView.Adapter<*>,
+        val observer: RecyclerView.AdapterDataObserver
+    )
+
+    private class DataObserver(private val onDataChanged: () -> Unit) : RecyclerView.AdapterDataObserver() {
+        override fun onChanged() = onDataChanged()
+        override fun onItemRangeRemoved(positionStart: Int, itemCount: Int) = onDataChanged()
+        override fun onItemRangeMoved(fromPosition: Int, toPosition: Int, itemCount: Int) = onDataChanged()
+        override fun onItemRangeInserted(positionStart: Int, itemCount: Int) = onDataChanged()
+        override fun onItemRangeChanged(positionStart: Int, itemCount: Int) = onDataChanged()
+        override fun onItemRangeChanged(positionStart: Int, itemCount: Int, payload: Any?) = onDataChanged()
+    }
+
+    private class OnRecyclerViewDetachedFromWindow(private val onDetach: () -> Unit) : View.OnAttachStateChangeListener {
+        override fun onViewAttachedToWindow(v: View) = Unit
+        override fun onViewDetachedFromWindow(v: View) = onDetach()
     }
 }

--- a/recycler-view-divider/src/main/kotlin/com/fondesa/recyclerviewdivider/DividerBuilder.kt
+++ b/recycler-view-divider/src/main/kotlin/com/fondesa/recyclerviewdivider/DividerBuilder.kt
@@ -28,6 +28,7 @@ import androidx.core.content.ContextCompat
 import androidx.recyclerview.widget.GridLayoutManager
 import androidx.recyclerview.widget.LinearLayoutManager
 import androidx.recyclerview.widget.RecyclerView
+import com.fondesa.recyclerviewdivider.cache.InMemoryGridCache
 import com.fondesa.recyclerviewdivider.drawable.DrawableProvider
 import com.fondesa.recyclerviewdivider.drawable.DrawableProviderImpl
 import com.fondesa.recyclerviewdivider.drawable.getThemeDrawable
@@ -333,7 +334,8 @@ public class DividerBuilder internal constructor(private val context: Context) {
                 isLastDividerVisible = isLastDividerVisible,
                 areSideDividersVisible = areSideDividersVisible
             ),
-            offsetProvider = offsetProvider ?: DividerOffsetProviderImpl(areSideDividersVisible)
+            offsetProvider = offsetProvider ?: DividerOffsetProviderImpl(areSideDividersVisible),
+            cache = InMemoryGridCache()
         )
     }
 

--- a/recycler-view-divider/src/main/kotlin/com/fondesa/recyclerviewdivider/cache/GridCache.kt
+++ b/recycler-view-divider/src/main/kotlin/com/fondesa/recyclerviewdivider/cache/GridCache.kt
@@ -1,0 +1,48 @@
+/*
+ * Copyright (c) 2021 Giorgio Antonioli
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.fondesa.recyclerviewdivider.cache
+
+import androidx.recyclerview.widget.RecyclerView
+import com.fondesa.recyclerviewdivider.Grid
+
+/**
+ * Caches the [Grid] used to calculate the offsets and draw dividers.
+ */
+internal interface GridCache {
+    /**
+     * Gets the [Grid] from the cache, if any.
+     *
+     * @param spanCount the span count of the [RecyclerView] which shows the dividers.
+     * @param itemCount the number of items of the [RecyclerView] which shows the dividers.
+     * @return the grid in cache, or null if the there isn't a valid [Grid] in cache for the given parameters.
+     */
+    fun get(spanCount: Int, itemCount: Int): Grid?
+
+    /**
+     * Saves the [Grid] into the cache.
+     *
+     * @param spanCount the span count of the [RecyclerView] which shows the dividers.
+     * @param itemCount the number of items of the [RecyclerView] which shows the dividers.
+     * @param grid the [Grid] which should be saved.
+     */
+    fun put(spanCount: Int, itemCount: Int, grid: Grid)
+
+    /**
+     * Clears the cache.
+     */
+    fun clear()
+}

--- a/recycler-view-divider/src/main/kotlin/com/fondesa/recyclerviewdivider/cache/InMemoryGridCache.kt
+++ b/recycler-view-divider/src/main/kotlin/com/fondesa/recyclerviewdivider/cache/InMemoryGridCache.kt
@@ -1,0 +1,50 @@
+/*
+ * Copyright (c) 2021 Giorgio Antonioli
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.fondesa.recyclerviewdivider.cache
+
+import com.fondesa.recyclerviewdivider.Grid
+
+/**
+ * Implementation of [GridCache] which stores the grid in memory.
+ */
+internal class InMemoryGridCache : GridCache {
+    private var cacheEntry: CacheEntry? = null
+
+    override fun get(spanCount: Int, itemCount: Int): Grid? {
+        val cacheEntry = cacheEntry ?: return null
+        val isCacheValid = cacheEntry.spanCount == spanCount && cacheEntry.itemCount == itemCount
+        return cacheEntry.grid.takeIf { isCacheValid }
+    }
+
+    override fun put(spanCount: Int, itemCount: Int, grid: Grid) {
+        cacheEntry = CacheEntry(
+            spanCount = spanCount,
+            itemCount = itemCount,
+            grid = grid
+        )
+    }
+
+    override fun clear() {
+        cacheEntry = null
+    }
+
+    private data class CacheEntry(
+        val spanCount: Int,
+        val itemCount: Int,
+        val grid: Grid
+    )
+}

--- a/recycler-view-divider/src/test/kotlin/com/fondesa/recyclerviewdivider/DividerBuilderTest.kt
+++ b/recycler-view-divider/src/test/kotlin/com/fondesa/recyclerviewdivider/DividerBuilderTest.kt
@@ -26,6 +26,7 @@ import androidx.annotation.Px
 import androidx.core.content.ContextCompat
 import androidx.test.core.app.ActivityScenario
 import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.fondesa.recyclerviewdivider.cache.InMemoryGridCache
 import com.fondesa.recyclerviewdivider.drawable.DrawableProvider
 import com.fondesa.recyclerviewdivider.drawable.DrawableProviderImpl
 import com.fondesa.recyclerviewdivider.drawable.transparentDrawable
@@ -715,6 +716,7 @@ class DividerBuilderTest {
         assertFalse((decoration.visibilityProvider as VisibilityProviderImpl).isFirstDividerVisible)
         assertFalse(decoration.visibilityProvider.isLastDividerVisible)
         assertFalse(decoration.visibilityProvider.areSideDividersVisible)
+        assertTrue(decoration.cache is InMemoryGridCache)
         verify(logger).logWarning(
             "Can't render the divider without a color/drawable. " +
                 "Specify \"recyclerViewDividerDrawable\" or \"android:listDivider\" in the theme or set a color/drawable " +
@@ -742,6 +744,7 @@ class DividerBuilderTest {
         assertFalse((decoration.visibilityProvider as VisibilityProviderImpl).isFirstDividerVisible)
         assertFalse(decoration.visibilityProvider.isLastDividerVisible)
         assertFalse(decoration.visibilityProvider.areSideDividersVisible)
+        assertTrue(decoration.cache is InMemoryGridCache)
         verifyZeroInteractions(logger)
     }
 
@@ -769,6 +772,7 @@ class DividerBuilderTest {
         assertTrue((decoration.visibilityProvider as VisibilityProviderImpl).isFirstDividerVisible)
         assertTrue(decoration.visibilityProvider.isLastDividerVisible)
         assertTrue(decoration.visibilityProvider.areSideDividersVisible)
+        assertTrue(decoration.cache is InMemoryGridCache)
         verifyZeroInteractions(logger)
     }
 

--- a/recycler-view-divider/src/test/kotlin/com/fondesa/recyclerviewdivider/cache/InMemoryGridCacheTest.kt
+++ b/recycler-view-divider/src/test/kotlin/com/fondesa/recyclerviewdivider/cache/InMemoryGridCacheTest.kt
@@ -1,0 +1,60 @@
+/*
+ * Copyright (c) 2021 Giorgio Antonioli
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.fondesa.recyclerviewdivider.cache
+
+import com.fondesa.recyclerviewdivider.test.dummyGrid
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+
+/**
+ * Tests of [InMemoryGridCache].
+ */
+class InMemoryGridCacheTest {
+    private val cache = InMemoryGridCache()
+
+    @Test
+    fun `put, get - same item count and span count`() {
+        val grid = dummyGrid()
+
+        cache.put(4, 5, grid)
+
+        assertEquals(grid, cache.get(4, 5))
+        assertEquals(grid, cache.get(4, 5))
+    }
+
+    @Test
+    fun `put, get - different item count or span count`() {
+        val grid = dummyGrid()
+
+        cache.put(4, 5, grid)
+
+        assertNull(cache.get(4, 3))
+        assertNull(cache.get(3, 5))
+        assertNull(cache.get(3, 3))
+    }
+
+    @Test
+    fun `put, get, clear - no grid in cache`() {
+        val grid = dummyGrid()
+
+        cache.put(4, 5, grid)
+        cache.clear()
+
+        assertNull(cache.get(4, 5))
+    }
+}


### PR DESCRIPTION
The grid used by `DividerItemDecoration` will be now cached.
In a complex `GridLayoutManager` with a lot of items, this makes a big improvement.

Related issue: #130 
