### PR TITLE
Revert "Get item count from RecyclerView.State"

### DIFF
--- a/recycler-view-divider/src/main/kotlin/com/fondesa/recyclerviewdivider/BaseDividerItemDecoration.kt
+++ b/recycler-view-divider/src/main/kotlin/com/fondesa/recyclerviewdivider/BaseDividerItemDecoration.kt
@@ -99,7 +99,7 @@ public abstract class BaseDividerItemDecoration(
         outRect.setEmpty()
         val adapter = parent.adapter ?: return
         adapter.setupDataObserver()
-        val itemCount = state.itemCount
+        val itemCount = adapter.itemCount
         if (itemCount == 0) return
         val layoutManager = parent.layoutManager ?: return
         val itemIndex = parent.getChildAdapterPositionOrNull(view) ?: return
@@ -113,7 +113,7 @@ public abstract class BaseDividerItemDecoration(
         if (asSpace) return
         val adapter = parent.adapter ?: return
         adapter.setupDataObserver()
-        val itemCount = state.itemCount
+        val itemCount = adapter.itemCount
         if (itemCount == 0) return
         val layoutManager = parent.layoutManager ?: return
         onDraw(canvas = c, recyclerView = parent, layoutManager = layoutManager, itemCount = itemCount)

--- a/recycler-view-divider/src/test/kotlin/com/fondesa/recyclerviewdivider/BaseDividerItemDecorationTest.kt
+++ b/recycler-view-divider/src/test/kotlin/com/fondesa/recyclerviewdivider/BaseDividerItemDecorationTest.kt
@@ -101,15 +101,14 @@ class BaseDividerItemDecorationTest {
     @Test
     fun `getItemOffsets - adapter with no items - overload not invoked`() {
         val recyclerView = RecyclerView(context)
-        val adapter = mock<RecyclerView.Adapter<*>>()
+        val adapter = mock<RecyclerView.Adapter<*>> {
+            on(it.itemCount) doReturn 0
+        }
         recyclerView.adapter = adapter
         val decoration = MockDecoration().also { it.addTo(recyclerView) }
         val rect = Rect()
-        val state = mock<RecyclerView.State> {
-            on(it.itemCount) doReturn 0
-        }
 
-        decoration.getItemOffsets(rect, View(context), recyclerView, state)
+        decoration.getItemOffsets(rect, View(context), recyclerView, RecyclerView.State())
 
         assertEquals(Rect(), rect)
         verifyZeroInteractions(getItemOffsets)
@@ -118,15 +117,14 @@ class BaseDividerItemDecorationTest {
     @Test
     fun `getItemOffsets - layout manager not attached - overload not invoked`() {
         val recyclerView = RecyclerView(context)
-        val adapter = mock<RecyclerView.Adapter<*>>()
+        val adapter = mock<RecyclerView.Adapter<*>> {
+            on(it.itemCount) doReturn 4
+        }
         recyclerView.adapter = adapter
         val decoration = MockDecoration().also { it.addTo(recyclerView) }
         val rect = Rect()
-        val state = mock<RecyclerView.State> {
-            on(it.itemCount) doReturn 4
-        }
 
-        decoration.getItemOffsets(rect, View(context), recyclerView, state)
+        decoration.getItemOffsets(rect, View(context), recyclerView, RecyclerView.State())
 
         assertEquals(Rect(), rect)
         verifyZeroInteractions(getItemOffsets)
@@ -139,15 +137,14 @@ class BaseDividerItemDecorationTest {
             doReturn(RecyclerView.NO_POSITION).whenever(it).getChildAdapterPosition(itemView)
         }
         recyclerView.layoutManager = linearLayoutManager()
-        val adapter = mock<RecyclerView.Adapter<*>>()
+        val adapter = mock<RecyclerView.Adapter<*>> {
+            on(it.itemCount) doReturn 4
+        }
         recyclerView.adapter = adapter
         val decoration = MockDecoration().also { it.addTo(recyclerView) }
         val rect = Rect()
-        val state = mock<RecyclerView.State> {
-            on(it.itemCount) doReturn 4
-        }
 
-        decoration.getItemOffsets(rect, itemView, recyclerView, state)
+        decoration.getItemOffsets(rect, itemView, recyclerView, RecyclerView.State())
 
         assertEquals(Rect(), rect)
         verifyZeroInteractions(getItemOffsets)
@@ -161,15 +158,14 @@ class BaseDividerItemDecorationTest {
         }
         val layoutManager = linearLayoutManager()
         recyclerView.layoutManager = layoutManager
-        val adapter = mock<RecyclerView.Adapter<*>>()
+        val adapter = mock<RecyclerView.Adapter<*>> {
+            on(it.itemCount) doReturn 4
+        }
         recyclerView.adapter = adapter
         val decoration = MockDecoration().also { it.addTo(recyclerView) }
         val rect = Rect()
-        val state = mock<RecyclerView.State> {
-            on(it.itemCount) doReturn 4
-        }
 
-        decoration.getItemOffsets(rect, itemView, recyclerView, state)
+        decoration.getItemOffsets(rect, itemView, recyclerView, RecyclerView.State())
 
         assertEquals(Rect(), rect)
         verify(getItemOffsets).invoke(layoutManager = layoutManager, outRect = rect, itemView = itemView, itemCount = 4, itemIndex = 2)
@@ -183,7 +179,9 @@ class BaseDividerItemDecorationTest {
         }
         val layoutManager = linearLayoutManager()
         recyclerView.layoutManager = layoutManager
-        val adapter = mock<RecyclerView.Adapter<*>>()
+        val adapter = mock<RecyclerView.Adapter<*>> {
+            on(it.itemCount) doReturn 4
+        }
         recyclerView.adapter = adapter
         val decoration = MockDecoration().also { it.addTo(recyclerView) }
         val rect = Rect()
@@ -222,15 +220,14 @@ class BaseDividerItemDecorationTest {
     @Test
     fun `onDraw - adapter with no items, overload not invoked`() {
         val recyclerView = RecyclerView(context)
-        val adapter = mock<RecyclerView.Adapter<*>>()
+        val adapter = mock<RecyclerView.Adapter<*>> {
+            on(it.itemCount) doReturn 0
+        }
         recyclerView.adapter = adapter
         val decoration = MockDecoration().also { it.addTo(recyclerView) }
         val canvas = mock<Canvas>()
-        val state = mock<RecyclerView.State> {
-            on(it.itemCount) doReturn 0
-        }
 
-        decoration.onDraw(canvas, recyclerView, state)
+        decoration.onDraw(canvas, recyclerView, RecyclerView.State())
 
         verifyZeroInteractions(canvas)
         verifyZeroInteractions(onDraw)
@@ -239,15 +236,14 @@ class BaseDividerItemDecorationTest {
     @Test
     fun `onDraw - layout manager not attached - overload not invoked`() {
         val recyclerView = RecyclerView(context)
-        val adapter = mock<RecyclerView.Adapter<*>>()
+        val adapter = mock<RecyclerView.Adapter<*>> {
+            on(it.itemCount) doReturn 4
+        }
         recyclerView.adapter = adapter
         val decoration = MockDecoration().also { it.addTo(recyclerView) }
         val canvas = mock<Canvas>()
-        val state = mock<RecyclerView.State> {
-            on(it.itemCount) doReturn 4
-        }
 
-        decoration.onDraw(canvas, recyclerView, state)
+        decoration.onDraw(canvas, recyclerView, RecyclerView.State())
 
         verifyZeroInteractions(canvas)
         verifyZeroInteractions(onDraw)
@@ -258,15 +254,14 @@ class BaseDividerItemDecorationTest {
         val recyclerView = RecyclerView(context)
         val layoutManager = linearLayoutManager()
         recyclerView.layoutManager = layoutManager
-        val adapter = mock<RecyclerView.Adapter<*>>()
+        val adapter = mock<RecyclerView.Adapter<*>> {
+            on(it.itemCount) doReturn 4
+        }
         recyclerView.adapter = adapter
         val decoration = MockDecoration().also { it.addTo(recyclerView) }
         val canvas = mock<Canvas>()
-        val state = mock<RecyclerView.State> {
-            on(it.itemCount) doReturn 4
-        }
 
-        decoration.onDraw(canvas, recyclerView, state)
+        decoration.onDraw(canvas, recyclerView, RecyclerView.State())
 
         verifyZeroInteractions(canvas)
         verify(onDraw).invoke(canvas = canvas, recyclerView = recyclerView, layoutManager = layoutManager, itemCount = 4)
@@ -277,7 +272,9 @@ class BaseDividerItemDecorationTest {
         val recyclerView = RecyclerView(context)
         val layoutManager = linearLayoutManager()
         recyclerView.layoutManager = layoutManager
-        val adapter = mock<RecyclerView.Adapter<*>>()
+        val adapter = mock<RecyclerView.Adapter<*>> {
+            on(it.itemCount) doReturn 4
+        }
         recyclerView.adapter = adapter
         val decoration = MockDecoration().also { it.addTo(recyclerView) }
         val canvas = mock<Canvas>()

--- a/recycler-view-divider/src/test/kotlin/com/fondesa/recyclerviewdivider/test/ItemDecorationExtensions.kt
+++ b/recycler-view-divider/src/test/kotlin/com/fondesa/recyclerviewdivider/test/ItemDecorationExtensions.kt
@@ -41,13 +41,10 @@ internal fun RecyclerView.ItemDecoration.getItemOffsets(
     vararg views: View
 ): List<Rect> {
     val recyclerView = recyclerView(layoutManager, isRTL, views)
-    val state = mock<RecyclerView.State> {
-        on(it.itemCount) doReturn views.size
-    }
     return views.mapIndexed { index, view ->
         doReturn(index).whenever(recyclerView).getChildAdapterPosition(view)
         val rect = Rect()
-        getItemOffsets(rect, view, recyclerView, state)
+        getItemOffsets(rect, view, recyclerView, RecyclerView.State())
         rect
     }
 }
@@ -73,10 +70,7 @@ internal fun RecyclerView.ItemDecoration.onDraw(
         doCallRealMethod().whenever(it)
             .drawRect(leftCaptor.capture(), topCaptor.capture(), rightCaptor.capture(), bottomCaptor.capture(), any())
     }
-    val state = mock<RecyclerView.State> {
-        on(it.itemCount) doReturn views.size
-    }
-    onDraw(canvas, recyclerView, state)
+    onDraw(canvas, recyclerView, RecyclerView.State())
     // Since the argument captors are invoked in the same method, their size is equal.
     return (leftCaptor.allValues.indices).map { index ->
         Rect(
@@ -98,7 +92,9 @@ private fun recyclerView(
     }
     doReturn(views.size).whenever(recyclerView).childCount
     recyclerView.layoutManager = layoutManager
-    val adapter = mock<RecyclerView.Adapter<*>>()
+    val adapter = mock<RecyclerView.Adapter<*>> {
+        on(it.itemCount) doReturn views.size
+    }
     recyclerView.adapter = adapter
     views.forEachIndexed { index, view ->
         doReturn(view).whenever(recyclerView).getChildAt(index)


### PR DESCRIPTION
Reverts fondesa/recycler-view-divider#177

it enables to invalidate the decorations when the adapter data changes.