### PR TITLE
Fix item offset of last added item when divider shouldn't be shown

### DIFF
--- a/recycler-view-divider/src/main/kotlin/androidx/recyclerview/widget/MarkItemDecorationsDirty.kt
+++ b/recycler-view-divider/src/main/kotlin/androidx/recyclerview/widget/MarkItemDecorationsDirty.kt
@@ -1,0 +1,24 @@
+/*
+ * Copyright (c) 2021 Giorgio Antonioli
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package androidx.recyclerview.widget
+
+/**
+ * Exposes [RecyclerView.markItemDecorInsetsDirty] since it's package-protected.
+ */
+internal fun RecyclerView.markItemDecorationsDirty() {
+    markItemDecorInsetsDirty()
+}

--- a/recycler-view-divider/src/main/kotlin/com/fondesa/recyclerviewdivider/BaseDividerItemDecoration.kt
+++ b/recycler-view-divider/src/main/kotlin/com/fondesa/recyclerviewdivider/BaseDividerItemDecoration.kt
@@ -21,6 +21,7 @@ import android.graphics.Rect
 import android.view.View
 import androidx.annotation.VisibleForTesting
 import androidx.recyclerview.widget.RecyclerView
+import androidx.recyclerview.widget.markItemDecorationsDirty
 
 /**
  * Base implementation of [RecyclerView.ItemDecoration] which provides some utilities methods.
@@ -89,7 +90,9 @@ public abstract class BaseDividerItemDecoration(
      * Specifically, this callback is invoked every time a method of [RecyclerView.AdapterDataObserver] is invoked.
      */
     protected open fun onDataChanged() {
-        // No-op.
+        // In this way, getItemOffsets() will be executed also on the previous items.
+        // Do not call invalidateItemDecorations() since we don't need requestLayout().
+        attachStateListenerHolder?.recyclerView?.markItemDecorationsDirty()
     }
 
     final override fun getItemOffsets(outRect: Rect, view: View, parent: RecyclerView, state: RecyclerView.State) {

--- a/recycler-view-divider/src/test/kotlin/androidx/recyclerview/widget/MarkItemDecorationsDirtyTest.kt
+++ b/recycler-view-divider/src/test/kotlin/androidx/recyclerview/widget/MarkItemDecorationsDirtyTest.kt
@@ -1,0 +1,35 @@
+/*
+ * Copyright (c) 2021 Giorgio Antonioli
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package androidx.recyclerview.widget
+
+import com.nhaarman.mockitokotlin2.mock
+import com.nhaarman.mockitokotlin2.verify
+import org.junit.Test
+
+/**
+ * Tests of MarkItemDecorationsDirty.kt file.
+ */
+class MarkItemDecorationsDirtyTest {
+    @Test
+    fun `markItemDecorationsDirty - calls RecyclerView api`() {
+        val recyclerView = mock<RecyclerView>()
+
+        recyclerView.markItemDecorationsDirty()
+
+        verify(recyclerView).markItemDecorInsetsDirty()
+    }
+}

--- a/recycler-view-divider/src/test/kotlin/androidx/recyclerview/widget/MockRecyclerView.kt
+++ b/recycler-view-divider/src/test/kotlin/androidx/recyclerview/widget/MockRecyclerView.kt
@@ -1,0 +1,26 @@
+/*
+ * Copyright (c) 2021 Giorgio Antonioli
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package androidx.recyclerview.widget
+
+import android.content.Context
+
+/**
+ * Exposes [RecyclerView.markItemDecorInsetsDirty].
+ */
+internal class MockRecyclerView(context: Context) : RecyclerView(context) {
+    public override fun markItemDecorInsetsDirty() = super.markItemDecorInsetsDirty()
+}

--- a/recycler-view-divider/src/test/kotlin/com/fondesa/recyclerviewdivider/BaseDividerItemDecorationTest.kt
+++ b/recycler-view-divider/src/test/kotlin/com/fondesa/recyclerviewdivider/BaseDividerItemDecorationTest.kt
@@ -324,12 +324,6 @@ class BaseDividerItemDecorationTest {
     }
 
     @Test
-    fun `onDataChanged - callback invoked before RecyclerView is attached - exception not thrown`() {
-        // It shouldn't throw an exception.
-        MockDecoration().onDataChanged()
-    }
-
-    @Test
     fun `data observer - same registration until adapter changes`() {
         val recyclerView = RecyclerView(context)
         val adapter = mock<RecyclerView.Adapter<*>>()
@@ -411,7 +405,7 @@ class BaseDividerItemDecorationTest {
         override fun onDraw(canvas: Canvas, recyclerView: RecyclerView, layoutManager: RecyclerView.LayoutManager, itemCount: Int) =
             this@BaseDividerItemDecorationTest.onDraw(canvas, recyclerView, layoutManager, itemCount)
 
-        public override fun onDataChanged() {
+        override fun onDataChanged() {
             super.onDataChanged()
             this@BaseDividerItemDecorationTest.onDataChanged()
         }

--- a/recycler-view-divider/src/test/kotlin/com/fondesa/recyclerviewdivider/BaseDividerItemDecorationTest.kt
+++ b/recycler-view-divider/src/test/kotlin/com/fondesa/recyclerviewdivider/BaseDividerItemDecorationTest.kt
@@ -324,6 +324,12 @@ class BaseDividerItemDecorationTest {
     }
 
     @Test
+    fun `onDataChanged - callback invoked before RecyclerView is attached - exception not thrown`() {
+        // It shouldn't throw an exception.
+        MockDecoration().onDataChanged()
+    }
+
+    @Test
     fun `data observer - same registration until adapter changes`() {
         val recyclerView = RecyclerView(context)
         val adapter = mock<RecyclerView.Adapter<*>>()
@@ -405,7 +411,7 @@ class BaseDividerItemDecorationTest {
         override fun onDraw(canvas: Canvas, recyclerView: RecyclerView, layoutManager: RecyclerView.LayoutManager, itemCount: Int) =
             this@BaseDividerItemDecorationTest.onDraw(canvas, recyclerView, layoutManager, itemCount)
 
-        override fun onDataChanged() {
+        public override fun onDataChanged() {
             super.onDataChanged()
             this@BaseDividerItemDecorationTest.onDataChanged()
         }


### PR DESCRIPTION
This happens when calling `notifyItemInserted()` on the last added item and the last divider is hidden.