### PR TITLE
Remove ReleasesHub

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -24,7 +24,6 @@ buildscript {
         classpath libs.kotlin.gp
         classpath libs.ktlint.gp
         classpath libs.recyclerViewDivider.buildTools
-        classpath libs.releasesHub.gp
     }
 }
 
@@ -33,20 +32,6 @@ allprojects {
     apply from: rootProject.file("build-tools/kotlin.gradle")
     // Adds the version of this library to all the projects, including the root project.
     apply plugin: "recycler-view-divider-version"
-}
-
-apply plugin: "com.dipien.releaseshub.gradle.plugin"
-
-releasesHub {
-    autoDetectDependenciesPaths = false
-    dependenciesPaths = [
-            "gradle/libs.versions.toml",
-            "gradle/wrapper/gradle-wrapper.properties"
-    ]
-    pullRequestLabels = ["dependencies"]
-    headBranchPrefix = "update-dependency/"
-    gitHubRepositoryOwner = "fondesa"
-    gitHubRepositoryName = "recycler-view-divider"
 }
 
 apply plugin: "com.github.breadmoirai.github-release"
@@ -64,7 +49,6 @@ githubRelease {
 def gitHubToken = project.properties["github.token"] ?: System.getenv("GITHUB_TOKEN")
 if (gitHubToken != null) {
     githubRelease.token = gitHubToken
-    releasesHub.gitHubWriteToken = gitHubToken
 }
 
 task clean(type: Delete) {

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -14,8 +14,6 @@
 # limitations under the License.
 #
 
-# Do NOT use the [versions] tag because it's not supported by ReleasesHub.
-
 [libraries]
 android-gp-api = "com.android.tools.build:gradle-api:7.4.0"
 android-gp-impl = "com.android.tools.build:gradle:7.4.0"
@@ -32,5 +30,4 @@ ktlint-gp = "org.jlleitschuh.gradle:ktlint-gradle:11.0.0"
 mockito-core = "org.mockito:mockito-core:5.0.0"
 mockito-kotlin = "org.mockito.kotlin:mockito-kotlin:4.1.0"
 recyclerViewDivider-buildTools = { module = "com.fondesa.recyclerviewdivider.buildtools:build-tools" }
-releasesHub-gp = "com.dipien:releases-hub-gradle-plugin:4.0.0"
 robolectric = "org.robolectric:robolectric:4.9.2"


### PR DESCRIPTION
Since now Renovate is configured, ReleasesHub can be replaced.